### PR TITLE
Activations

### DIFF
--- a/src/activation.rs
+++ b/src/activation.rs
@@ -1,3 +1,5 @@
+use std::f64;
+
 /// Activation functions
 pub trait Activation {
     fn new() -> Self;
@@ -43,11 +45,31 @@ impl Activation for Identity {
     }
 }
 
+pub struct HyperbolicTangent;
+
+impl Activation for HyperbolicTangent {
+    fn new() -> HyperbolicTangent {
+        return HyperbolicTangent;
+    }
+
+    /// Calculates the tanh of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        x.tanh()
+    }
+
+    /// Calculates the Derivative tanh of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        let tanh_factor = x.tanh();
+        1f64 - (tanh_factor * tanh_factor)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Activation;
     use super::Sigmoid;
     use super::Identity;
+    use super::HyperbolicTangent;
 
     #[test]
     fn sigmoid_test() {
@@ -71,6 +93,18 @@ mod tests {
     fn identity_derivative_test() {
         let activation = Identity::new();
         assert_approx_eq!(activation.derivative(15f64), 1f64);
+    }
+
+    #[test]
+    fn tanh_test() {
+        let activation = HyperbolicTangent::new();
+        assert_approx_eq!(activation.calc(3f64), 0.995054754f64);
+    }
+
+    #[test]
+    fn tanh_derivative_test() {
+        let activation = HyperbolicTangent::new();
+        assert_approx_eq!(activation.derivative(3f64), 0.0098660372f64);
     }
 }
 

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -25,10 +25,29 @@ impl Activation for Sigmoid {
     }
 }
 
+pub struct Identity;
+
+impl Activation for Identity {
+    fn new() -> Identity {
+        return Identity;
+    }
+
+    /// Calculates the Identity of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        x
+    }
+
+    /// Calculates the Derivative Identity of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        1f64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Activation;
     use super::Sigmoid;
+    use super::Identity;
 
     #[test]
     fn sigmoid_test() {
@@ -41,4 +60,17 @@ mod tests {
         let activation = Sigmoid::new();
         assert_approx_eq!(activation.derivative(5f64), -20f64);
     }
+
+    #[test]
+    fn identity_test() {
+        let activation = Identity::new();
+        assert_approx_eq!(activation.calc(5f64), 5f64);
+    }
+
+    #[test]
+    fn identity_derivative_test() {
+        let activation = Identity::new();
+        assert_approx_eq!(activation.derivative(15f64), 1f64);
+    }
 }
+

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -82,6 +82,32 @@ impl Activation for SoftPlus {
     }
 }
 
+pub struct RectifiedLinearUnit;
+
+impl Activation for RectifiedLinearUnit {
+    fn new() -> RectifiedLinearUnit {
+        return RectifiedLinearUnit;
+    }
+
+    /// Calculates the RectifiedLinearUnit of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        if x <= 0f64 {
+            0f64
+        } else {
+            x
+        }
+    }
+
+    /// Calculates the Derivative RectifiedLinearUnit of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        if x <= 0f64 {
+            0f64
+        } else {
+            x
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Activation;
@@ -89,6 +115,7 @@ mod tests {
     use super::Identity;
     use super::HyperbolicTangent;
     use super::SoftPlus;
+    use super::RectifiedLinearUnit;
 
     #[test]
     fn sigmoid_test() {
@@ -136,6 +163,20 @@ mod tests {
     fn softplus_derivative_test() {
         let activation = SoftPlus::new();
         assert_approx_eq!(activation.derivative(-1f64), 0.2689414214f64);
+    }
+
+    #[test]
+    fn rectifiedlinearunit_test() {
+        let activation = RectifiedLinearUnit::new();
+        assert_approx_eq!(activation.calc(3.4f64), 3.4f64);
+        assert_approx_eq!(activation.calc(-3.4f64), 0f64);
+    }
+
+    #[test]
+    fn rectifiedlinearunit_derivative_test() {
+        let activation = RectifiedLinearUnit::new();
+        assert_approx_eq!(activation.derivative(-3.4f64), 0f64);
+        assert_approx_eq!(activation.derivative(3.4f64), 3.4f64);
     }
 }
 

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -64,12 +64,31 @@ impl Activation for HyperbolicTangent {
     }
 }
 
+pub struct SoftPlus;
+
+impl Activation for SoftPlus {
+    fn new() -> SoftPlus {
+        return SoftPlus;
+    }
+
+    /// Calculates the SoftPlus of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        (1f64 + x.exp()).ln()
+    }
+
+    /// Calculates the Derivative SoftPlus of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        1f64 / (1f64 + (-x).exp())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Activation;
     use super::Sigmoid;
     use super::Identity;
     use super::HyperbolicTangent;
+    use super::SoftPlus;
 
     #[test]
     fn sigmoid_test() {
@@ -105,6 +124,18 @@ mod tests {
     fn tanh_derivative_test() {
         let activation = HyperbolicTangent::new();
         assert_approx_eq!(activation.derivative(3f64), 0.0098660372f64);
+    }
+
+    #[test]
+    fn softplus_test() {
+        let activation = SoftPlus::new();
+        assert_approx_eq!(activation.calc(-1f64), 0.3132616875f64);
+    }
+
+    #[test]
+    fn softplus_derivative_test() {
+        let activation = SoftPlus::new();
+        assert_approx_eq!(activation.derivative(-1f64), 0.2689414214f64);
     }
 }
 


### PR DESCRIPTION
Added the identity, hyperbolic tangent, softplus, and Rectified Linear Unit (ReLU) activation functions.

It would probably be a good idea to break these up into their own files, especially if we add any further, but for now, it's fine.

I also noticed that this model doesn't fit some of the other fun activation functions. For example, having a new without parameter makes it annoying to create a Leaky ReLU or a Noisy ReLU. 

Also, setting up a Parametric ReLU won't work in the back prop function as it is (since it's no longer a hyper parameter but a parameter). Not sure how to fix that though.
