### PR TITLE
Activation reorg

### DIFF
--- a/src/activation/hyperbolictangent.rs
+++ b/src/activation/hyperbolictangent.rs
@@ -1,0 +1,40 @@
+use std::f64;
+use activation::Activation;
+
+pub struct HyperbolicTangent;
+
+impl Activation for HyperbolicTangent {
+    fn new() -> HyperbolicTangent {
+        return HyperbolicTangent;
+    }
+
+    /// Calculates the tanh of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        x.tanh()
+    }
+
+    /// Calculates the Derivative tanh of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        let tanh_factor = x.tanh();
+        1f64 - (tanh_factor * tanh_factor)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::Activation;
+    use super::HyperbolicTangent;
+
+    #[test]
+    fn tanh_test() {
+        let activation = HyperbolicTangent::new();
+        assert_approx_eq!(activation.calc(3f64), 0.995054754f64);
+    }
+
+    #[test]
+    fn tanh_derivative_test() {
+        let activation = HyperbolicTangent::new();
+        assert_approx_eq!(activation.derivative(3f64), 0.0098660372f64);
+    }
+}

--- a/src/activation/identity.rs
+++ b/src/activation/identity.rs
@@ -1,0 +1,38 @@
+use activation::Activation;
+
+pub struct Identity;
+
+impl Activation for Identity {
+    fn new() -> Identity {
+        return Identity;
+    }
+
+    /// Calculates the Identity of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        x
+    }
+
+    /// Calculates the Derivative Identity of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        1f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Activation;
+    use super::Identity;
+
+    #[test]
+    fn identity_test() {
+        let activation = Identity::new();
+        assert_approx_eq!(activation.calc(5f64), 5f64);
+    }
+
+    #[test]
+    fn identity_derivative_test() {
+        let activation = Identity::new();
+        assert_approx_eq!(activation.derivative(15f64), 1f64);
+    }
+}
+

--- a/src/activation/mod.rs
+++ b/src/activation/mod.rs
@@ -1,12 +1,12 @@
-use std::f64;
-
 pub mod sigmoid;
 pub mod identity;
 pub mod hyperbolictangent;
+pub mod softplus;
 
 pub use self::sigmoid::Sigmoid;
 pub use self::identity::Identity;
 pub use self::hyperbolictangent::HyperbolicTangent;
+pub use self::softplus::SoftPlus;
 
 /// Activation functions
 pub trait Activation {
@@ -15,24 +15,6 @@ pub trait Activation {
     fn calc(&self, x: f64) -> f64;
     // Derivative
     fn derivative(&self, x: f64) -> f64;
-}
-
-pub struct SoftPlus;
-
-impl Activation for SoftPlus {
-    fn new() -> SoftPlus {
-        return SoftPlus;
-    }
-
-    /// Calculates the SoftPlus of input `x`
-    fn calc(&self, x: f64) -> f64 {
-        (1f64 + x.exp()).ln()
-    }
-
-    /// Calculates the Derivative SoftPlus of input `x`
-    fn derivative(&self, x: f64) -> f64 {
-        1f64 / (1f64 + (-x).exp())
-    }
 }
 
 pub struct RectifiedLinearUnit;
@@ -64,20 +46,7 @@ impl Activation for RectifiedLinearUnit {
 #[cfg(test)]
 mod tests {
     use super::Activation;
-    use super::SoftPlus;
     use super::RectifiedLinearUnit;
-
-    #[test]
-    fn softplus_test() {
-        let activation = SoftPlus::new();
-        assert_approx_eq!(activation.calc(-1f64), 0.3132616875f64);
-    }
-
-    #[test]
-    fn softplus_derivative_test() {
-        let activation = SoftPlus::new();
-        assert_approx_eq!(activation.derivative(-1f64), 0.2689414214f64);
-    }
 
     #[test]
     fn rectifiedlinearunit_test() {

--- a/src/activation/mod.rs
+++ b/src/activation/mod.rs
@@ -2,9 +2,11 @@ use std::f64;
 
 pub mod sigmoid;
 pub mod identity;
+pub mod hyperbolictangent;
 
 pub use self::sigmoid::Sigmoid;
 pub use self::identity::Identity;
+pub use self::hyperbolictangent::HyperbolicTangent;
 
 /// Activation functions
 pub trait Activation {
@@ -13,25 +15,6 @@ pub trait Activation {
     fn calc(&self, x: f64) -> f64;
     // Derivative
     fn derivative(&self, x: f64) -> f64;
-}
-
-pub struct HyperbolicTangent;
-
-impl Activation for HyperbolicTangent {
-    fn new() -> HyperbolicTangent {
-        return HyperbolicTangent;
-    }
-
-    /// Calculates the tanh of input `x`
-    fn calc(&self, x: f64) -> f64 {
-        x.tanh()
-    }
-
-    /// Calculates the Derivative tanh of input `x`
-    fn derivative(&self, x: f64) -> f64 {
-        let tanh_factor = x.tanh();
-        1f64 - (tanh_factor * tanh_factor)
-    }
 }
 
 pub struct SoftPlus;
@@ -81,21 +64,8 @@ impl Activation for RectifiedLinearUnit {
 #[cfg(test)]
 mod tests {
     use super::Activation;
-    use super::HyperbolicTangent;
     use super::SoftPlus;
     use super::RectifiedLinearUnit;
-
-    #[test]
-    fn tanh_test() {
-        let activation = HyperbolicTangent::new();
-        assert_approx_eq!(activation.calc(3f64), 0.995054754f64);
-    }
-
-    #[test]
-    fn tanh_derivative_test() {
-        let activation = HyperbolicTangent::new();
-        assert_approx_eq!(activation.derivative(3f64), 0.0098660372f64);
-    }
 
     #[test]
     fn softplus_test() {

--- a/src/activation/mod.rs
+++ b/src/activation/mod.rs
@@ -1,8 +1,10 @@
 use std::f64;
 
 pub mod sigmoid;
+pub mod identity;
 
 pub use self::sigmoid::Sigmoid;
+pub use self::identity::Identity;
 
 /// Activation functions
 pub trait Activation {
@@ -11,24 +13,6 @@ pub trait Activation {
     fn calc(&self, x: f64) -> f64;
     // Derivative
     fn derivative(&self, x: f64) -> f64;
-}
-
-pub struct Identity;
-
-impl Activation for Identity {
-    fn new() -> Identity {
-        return Identity;
-    }
-
-    /// Calculates the Identity of input `x`
-    fn calc(&self, x: f64) -> f64 {
-        x
-    }
-
-    /// Calculates the Derivative Identity of input `x`
-    fn derivative(&self, x: f64) -> f64 {
-        1f64
-    }
 }
 
 pub struct HyperbolicTangent;
@@ -97,22 +81,9 @@ impl Activation for RectifiedLinearUnit {
 #[cfg(test)]
 mod tests {
     use super::Activation;
-    use super::Identity;
     use super::HyperbolicTangent;
     use super::SoftPlus;
     use super::RectifiedLinearUnit;
-
-    #[test]
-    fn identity_test() {
-        let activation = Identity::new();
-        assert_approx_eq!(activation.calc(5f64), 5f64);
-    }
-
-    #[test]
-    fn identity_derivative_test() {
-        let activation = Identity::new();
-        assert_approx_eq!(activation.derivative(15f64), 1f64);
-    }
 
     #[test]
     fn tanh_test() {

--- a/src/activation/mod.rs
+++ b/src/activation/mod.rs
@@ -2,11 +2,13 @@ pub mod sigmoid;
 pub mod identity;
 pub mod hyperbolictangent;
 pub mod softplus;
+pub mod rectifiedlinearunit;
 
 pub use self::sigmoid::Sigmoid;
 pub use self::identity::Identity;
 pub use self::hyperbolictangent::HyperbolicTangent;
 pub use self::softplus::SoftPlus;
+pub use self::rectifiedlinearunit::RectifiedLinearUnit;
 
 /// Activation functions
 pub trait Activation {
@@ -17,49 +19,4 @@ pub trait Activation {
     fn derivative(&self, x: f64) -> f64;
 }
 
-pub struct RectifiedLinearUnit;
-
-impl Activation for RectifiedLinearUnit {
-    fn new() -> RectifiedLinearUnit {
-        return RectifiedLinearUnit;
-    }
-
-    /// Calculates the RectifiedLinearUnit of input `x`
-    fn calc(&self, x: f64) -> f64 {
-        if x <= 0f64 {
-            0f64
-        } else {
-            x
-        }
-    }
-
-    /// Calculates the Derivative RectifiedLinearUnit of input `x`
-    fn derivative(&self, x: f64) -> f64 {
-        if x <= 0f64 {
-            0f64
-        } else {
-            x
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Activation;
-    use super::RectifiedLinearUnit;
-
-    #[test]
-    fn rectifiedlinearunit_test() {
-        let activation = RectifiedLinearUnit::new();
-        assert_approx_eq!(activation.calc(3.4f64), 3.4f64);
-        assert_approx_eq!(activation.calc(-3.4f64), 0f64);
-    }
-
-    #[test]
-    fn rectifiedlinearunit_derivative_test() {
-        let activation = RectifiedLinearUnit::new();
-        assert_approx_eq!(activation.derivative(-3.4f64), 0f64);
-        assert_approx_eq!(activation.derivative(3.4f64), 3.4f64);
-    }
-}
 

--- a/src/activation/mod.rs
+++ b/src/activation/mod.rs
@@ -1,5 +1,9 @@
 use std::f64;
 
+pub mod sigmoid;
+
+pub use self::sigmoid::Sigmoid;
+
 /// Activation functions
 pub trait Activation {
     fn new() -> Self;
@@ -7,24 +11,6 @@ pub trait Activation {
     fn calc(&self, x: f64) -> f64;
     // Derivative
     fn derivative(&self, x: f64) -> f64;
-}
-
-pub struct Sigmoid;
-
-impl Activation for Sigmoid {
-    fn new() -> Sigmoid {
-        return Sigmoid;
-    }
-
-    /// Calculates the Sigmoid of input `x`
-    fn calc(&self, x: f64) -> f64 {
-        1f64 / (1f64 + (-x).exp())
-    }
-
-    /// Calculates the Derivative Sigmoid of input `x`
-    fn derivative(&self, x: f64) -> f64 {
-        x * (1f64 - x)
-    }
 }
 
 pub struct Identity;
@@ -111,23 +97,10 @@ impl Activation for RectifiedLinearUnit {
 #[cfg(test)]
 mod tests {
     use super::Activation;
-    use super::Sigmoid;
     use super::Identity;
     use super::HyperbolicTangent;
     use super::SoftPlus;
     use super::RectifiedLinearUnit;
-
-    #[test]
-    fn sigmoid_test() {
-        let activation = Sigmoid::new();
-        assert_approx_eq!(activation.calc(5f64), 0.9933071490f64);
-    }
-
-    #[test]
-    fn sigmoid_derivative_test() {
-        let activation = Sigmoid::new();
-        assert_approx_eq!(activation.derivative(5f64), -20f64);
-    }
 
     #[test]
     fn identity_test() {

--- a/src/activation/rectifiedlinearunit.rs
+++ b/src/activation/rectifiedlinearunit.rs
@@ -1,0 +1,47 @@
+use activation::Activation;
+
+pub struct RectifiedLinearUnit;
+
+impl Activation for RectifiedLinearUnit {
+    fn new() -> RectifiedLinearUnit {
+        return RectifiedLinearUnit;
+    }
+
+    /// Calculates the RectifiedLinearUnit of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        if x <= 0f64 {
+            0f64
+        } else {
+            x
+        }
+    }
+
+    /// Calculates the Derivative RectifiedLinearUnit of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        if x <= 0f64 {
+            0f64
+        } else {
+            x
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Activation;
+    use super::RectifiedLinearUnit;
+
+    #[test]
+    fn rectifiedlinearunit_test() {
+        let activation = RectifiedLinearUnit::new();
+        assert_approx_eq!(activation.calc(3.4f64), 3.4f64);
+        assert_approx_eq!(activation.calc(-3.4f64), 0f64);
+    }
+
+    #[test]
+    fn rectifiedlinearunit_derivative_test() {
+        let activation = RectifiedLinearUnit::new();
+        assert_approx_eq!(activation.derivative(-3.4f64), 0f64);
+        assert_approx_eq!(activation.derivative(3.4f64), 3.4f64);
+    }
+}

--- a/src/activation/sigmoid.rs
+++ b/src/activation/sigmoid.rs
@@ -1,0 +1,38 @@
+use activation::Activation;
+
+pub struct Sigmoid;
+
+impl Activation for Sigmoid {
+    fn new() -> Sigmoid {
+        return Sigmoid;
+    }
+
+    /// Calculates the Sigmoid of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        1f64 / (1f64 + (-x).exp())
+    }
+
+    /// Calculates the Derivative Sigmoid of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        x * (1f64 - x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Activation;
+    use super::Sigmoid;
+
+    #[test]
+    fn sigmoid_test() {
+        let activation = Sigmoid::new();
+        assert_approx_eq!(activation.calc(5f64), 0.9933071490f64);
+    }
+
+    #[test]
+    fn sigmoid_derivative_test() {
+        let activation = Sigmoid::new();
+        assert_approx_eq!(activation.derivative(5f64), -20f64);
+    }
+
+}

--- a/src/activation/softplus.rs
+++ b/src/activation/softplus.rs
@@ -1,0 +1,38 @@
+use std::f64;
+use activation::Activation;
+
+pub struct SoftPlus;
+
+impl Activation for SoftPlus {
+    fn new() -> SoftPlus {
+        return SoftPlus;
+    }
+
+    /// Calculates the SoftPlus of input `x`
+    fn calc(&self, x: f64) -> f64 {
+        (1f64 + x.exp()).ln()
+    }
+
+    /// Calculates the Derivative SoftPlus of input `x`
+    fn derivative(&self, x: f64) -> f64 {
+        1f64 / (1f64 + (-x).exp())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Activation;
+    use super::SoftPlus;
+
+    #[test]
+    fn softplus_test() {
+        let activation = SoftPlus::new();
+        assert_approx_eq!(activation.calc(-1f64), 0.3132616875f64);
+    }
+
+    #[test]
+    fn softplus_derivative_test() {
+        let activation = SoftPlus::new();
+        assert_approx_eq!(activation.derivative(-1f64), 0.2689414214f64);
+    }
+}


### PR DESCRIPTION
I Moved each of the activation implementations into their own file.

Then, to maintain the nice organisation for 'use' I re-exposed them through 'pub use' within the main module.