### PR TITLE
Per layer activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ fn main() {
         Sample::new(vec![1f64, 1f64, 1f64], vec![1f64])
     ];
     
-    let mut test = NeuralNetwork::new(dataset, Sigmoid::new());
+    let mut test = NeuralNetwork::new(dataset);
+
+    let sig_activation = Sigmoid::new();
 
     // 1st layer = 2 neurons - 3 inputs
-    test.add_layer(NeuralLayer::new(2, 3));
+    test.add_layer(NeuralLayer::new(2, 3, sig_activation));
 
     // 2nd layer = 1 neuron - 2 inputs
-    test.add_layer(NeuralLayer::new(1, 2));
+    test.add_layer(NeuralLayer::new(1, 2, sig_activation));
 
     test.error(|err| {
         println!("error({})", err.to_string());

--- a/examples/helloworld.rs
+++ b/examples/helloworld.rs
@@ -2,7 +2,6 @@ extern crate juggernaut;
 
 use juggernaut::nl::NeuralLayer;
 use juggernaut::nn::NeuralNetwork;
-use juggernaut::activation::Activation;
 use juggernaut::activation::Sigmoid;
 use juggernaut::sample::Sample;
 use juggernaut::matrix::MatrixTrait;
@@ -20,15 +19,15 @@ fn main() {
 
     println!("Creating the network...");
 
-    let mut test = NeuralNetwork::new(dataset, Sigmoid::new());
+    let mut test = NeuralNetwork::new(dataset);
 
     // 1st layer = 2 neurons - 3 inputs
-    test.add_layer(NeuralLayer::new(2, 3));
+    test.add_layer(NeuralLayer::new(2, 3, Sigmoid::new()));
 
     println!("First layer created: 2 neurons 3 inputs");
 
     // 2nd layer = 1 neuron - 2 inputs
-    test.add_layer(NeuralLayer::new(1, 2));
+    test.add_layer(NeuralLayer::new(1, 2, Sigmoid::new()));
 
     println!("Second layer created: 1 neuron 2 inputs");
 

--- a/examples/helloworld.rs
+++ b/examples/helloworld.rs
@@ -21,13 +21,14 @@ fn main() {
 
     let mut test = NeuralNetwork::new(dataset);
 
+    let sig_activation = Sigmoid::new();
     // 1st layer = 2 neurons - 3 inputs
-    test.add_layer(NeuralLayer::new(2, 3, Sigmoid::new()));
+    test.add_layer(NeuralLayer::new(2, 3, sig_activation));
 
     println!("First layer created: 2 neurons 3 inputs");
 
     // 2nd layer = 1 neuron - 2 inputs
-    test.add_layer(NeuralLayer::new(1, 2, Sigmoid::new()));
+    test.add_layer(NeuralLayer::new(1, 2, sig_activation));
 
     println!("Second layer created: 1 neuron 2 inputs");
 

--- a/src/activation/hyperbolictangent.rs
+++ b/src/activation/hyperbolictangent.rs
@@ -1,6 +1,7 @@
 use std::f64;
 use activation::Activation;
 
+#[derive(Copy, Clone)]
 pub struct HyperbolicTangent;
 
 impl HyperbolicTangent {

--- a/src/activation/identity.rs
+++ b/src/activation/identity.rs
@@ -1,5 +1,6 @@
 use activation::Activation;
 
+#[derive(Copy, Clone)]
 pub struct Identity;
 
 impl Identity {

--- a/src/activation/leakyrectifiedlinearunit.rs
+++ b/src/activation/leakyrectifiedlinearunit.rs
@@ -1,5 +1,6 @@
 use activation::Activation;
 
+#[derive(Copy, Clone)]
 pub struct LeakyRectifiedLinearUnit {
     alpha_gradient: f64
 }

--- a/src/activation/rectifiedlinearunit.rs
+++ b/src/activation/rectifiedlinearunit.rs
@@ -1,5 +1,6 @@
 use activation::Activation;
 
+#[derive(Copy, Clone)]
 pub struct RectifiedLinearUnit;
 
 impl RectifiedLinearUnit {

--- a/src/activation/sigmoid.rs
+++ b/src/activation/sigmoid.rs
@@ -1,5 +1,6 @@
 use activation::Activation;
 
+#[derive(Copy, Clone)]
 pub struct Sigmoid;
 
 impl Sigmoid {

--- a/src/activation/softplus.rs
+++ b/src/activation/softplus.rs
@@ -1,6 +1,7 @@
 use std::f64;
 use activation::Activation;
 
+#[derive(Copy, Clone)]
 pub struct SoftPlus;
 
 impl SoftPlus {

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -1,18 +1,21 @@
 use matrix::Matrix;
 use matrix::MatrixTrait;
+use activation::Activation;
 
 /// Represents a neural layer with its weights
 
 #[derive(Clone)]
-pub struct NeuralLayer {
+pub struct NeuralLayer<T: Activation> {
+    pub activation: T,
     pub inputs: usize,
     pub neurons: usize,
     pub weights: Matrix
 }
 
-impl NeuralLayer {
-    pub fn new(neurons: usize, inputs: usize) -> NeuralLayer {
+impl<T: Activation> NeuralLayer<T> {
+    pub fn new(neurons: usize, inputs: usize, activation: T) -> NeuralLayer<T> {
         NeuralLayer {
+            activation: activation,
             inputs: inputs,
             neurons: neurons,
             weights: Matrix::random(inputs, neurons)
@@ -24,10 +27,12 @@ impl NeuralLayer {
 mod tests {
     use super::*;
     use matrix::MatrixTrait;
+    use activation::Activation;
+    use activation::Sigmoid;
 
     #[test]
     fn new_neural_layer() {
-        let test = NeuralLayer::new(4, 3);
+        let test = NeuralLayer::new(4, 3, Sigmoid::new());
         assert_eq!(3usize, test.inputs);
         assert_eq!(4usize, test.neurons);
         assert_eq!(3usize, test.weights.rows());

--- a/src/nn.rs
+++ b/src/nn.rs
@@ -267,11 +267,13 @@ mod tests {
         let dataset = vec![Sample::new(vec![1f64, 0f64], vec![0f64])];
 
         let mut test = NeuralNetwork::new(dataset);
-
+        
+        let sig_activation = Sigmoid::new();
+        
         // 1st layer = 3 neurons - 2 inputs
-        test.add_layer(NeuralLayer::new(3, 2, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(3, 2, sig_activation));
         // 2nd layer = 1 neuron - 3 inputs
-        test.add_layer(NeuralLayer::new(1, 3, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(1, 3, sig_activation));
 
         let forward = test.forward(&test.samples);
 
@@ -284,8 +286,10 @@ mod tests {
 
         let mut test = NeuralNetwork::new(dataset);
 
+        let sig_activation = Sigmoid::new();
+
         // 1st layer = 1 neurons - 2 inputs
-        test.add_layer(NeuralLayer::new(1, 2, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(1, 2, sig_activation));
 
         let forward = test.forward(&test.samples);
 
@@ -303,10 +307,12 @@ mod tests {
 
         let mut test = NeuralNetwork::new(dataset);
 
+        let sig_activation = Sigmoid::new();
+
         // 1st layer = 3 neurons - 2 inputs
-        test.add_layer(NeuralLayer::new(3, 2, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(3, 2, sig_activation));
         // 2nd layer = 1 neuron - 3 inputs
-        test.add_layer(NeuralLayer::new(1, 3, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(1, 3, sig_activation));
 
         let forward = test.forward(&test.samples);
 
@@ -326,10 +332,12 @@ mod tests {
 
         let mut test = NeuralNetwork::new(dataset);
 
+        let sig_activation = Sigmoid::new();
+
         // 1st layer = 2 neurons - 3 inputs
-        test.add_layer(NeuralLayer::new(2, 3, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(2, 3, sig_activation));
         // 2nd layer = 1 neuron - 2 inputs
-        test.add_layer(NeuralLayer::new(1, 2, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(1, 2, sig_activation));
 
         test.train(5);
 
@@ -352,11 +360,13 @@ mod tests {
 
         // error should be more than 0
         test.error(|err| assert!(err > 0f64));
-
+        
+        let sig_activation = Sigmoid::new();
+        
         // 1st layer = 2 neurons - 3 inputs
-        test.add_layer(NeuralLayer::new(2, 3, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(2, 3, sig_activation));
         // 2nd layer = 1 neuron - 2 inputs
-        test.add_layer(NeuralLayer::new(1, 2, Sigmoid::new()));
+        test.add_layer(NeuralLayer::new(1, 2, sig_activation));
 
         test.train(5);
     }


### PR DESCRIPTION
Per layer activation functions as promised!

Currently all activation types can easily use derived copy/clone so they implement it. This makes it a bit easier in cases where you plan to use many layers the same way, makes the usability a bit nicer. That being said, I could foresee activation functions which can *not* be copy/clone-able which would be annoying to use in this way. 

But then, you would have to be managing that kind of thing separately at that point anyways so it's probably a moot point.