### PR TITLE
Removed some basic lint errors

### DIFF
--- a/src/activation/identity.rs
+++ b/src/activation/identity.rs
@@ -17,7 +17,7 @@ impl Activation for Identity {
     }
 
     /// Calculates the Derivative Identity of input `x`
-    fn derivative(&self, x: f64) -> f64 {
+    fn derivative(&self, _: f64) -> f64 {
         1f64
     }
 }

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -25,9 +25,8 @@ impl<T: Activation> NeuralLayer<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use nl::NeuralLayer;
     use matrix::MatrixTrait;
-    use activation::Activation;
     use activation::Sigmoid;
 
     #[test]

--- a/src/nn.rs
+++ b/src/nn.rs
@@ -240,12 +240,10 @@ impl <T: Activation> NeuralNetwork<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use activation::Sigmoid;
-    use activation::Activation;
     use sample::Sample;
     use nl::NeuralLayer;
-    use matrix::Matrix;
+    use nn::NeuralNetwork;
     use matrix::MatrixTrait;
 
     #[test]


### PR DESCRIPTION
identity.rs: unused variable name fix.
nl.rs: removed super::* and unused use fix.
nn.rs: removed super::* and changed to use of only specifically needed use.