### PR TITLE
fix(nl): using neurons as rows and inputs as cols

### DIFF
--- a/src/nl.rs
+++ b/src/nl.rs
@@ -5,9 +5,9 @@ use activation::Activation;
 /// Represents a neural layer with its weights
 pub struct NeuralLayer {
     pub activation: Box<Activation>,
-    pub inputs: usize,
-    pub neurons: usize,
-    pub weights: Matrix,
+    inputs: usize,
+    neurons: usize,
+    weights: Matrix,
 }
 
 impl NeuralLayer {
@@ -19,8 +19,25 @@ impl NeuralLayer {
             activation: Box::new(activation),
             inputs: inputs,
             neurons: neurons,
-            weights: Matrix::random(inputs, neurons),
+            weights: Matrix::random(neurons, inputs),
         }
+    }
+
+    pub fn neurons(&self) -> usize {
+        self.neurons
+    }
+
+    pub fn inputs(&self) -> usize {
+        self.inputs
+    }
+
+    // weights with bias node
+    pub fn weights(&self) -> &Matrix {
+        &self.weights
+    }
+
+    pub fn set_weights(&mut self, weights: Matrix) {
+        self.weights = weights;
     }
 }
 
@@ -33,9 +50,10 @@ mod tests {
     #[test]
     fn new_neural_layer() {
         let test = NeuralLayer::new(4, 3, Sigmoid::new());
-        assert_eq!(3usize, test.inputs);
-        assert_eq!(4usize, test.neurons);
-        assert_eq!(3usize, test.weights.rows());
-        assert_eq!(4usize, test.weights.cols());
+        assert_eq!(3usize, test.inputs());
+        assert_eq!(4usize, test.neurons());
+        
+        assert_eq!(4usize, test.weights.rows());
+        assert_eq!(3usize, test.weights.cols());
     }
 }


### PR DESCRIPTION
I made mistake in the usage of Matrix. Rows should be the neurons and columns should be the inputs. 

Also, I made a few fields private and added getter / setters. This feature can help us to implement bias node for `NeuralLayer`.